### PR TITLE
Add support for more than one template parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ module "apim_apis" {
         "type": "string",
         "default_value": "any"
       }]
-      template_parameter = {
+      template_parameters = [{
         "name": "example_template_parameter",
         "required": "true",
         "type": "string",
         "default_value": "any"
-      }
+      }]
       response = {
         "status_code": "200",
         "description": "any"
@@ -98,8 +98,8 @@ This can be used to add the response of each api operation. Response block suppo
 |status_code|The HTTP Status Code. i.e. 201| Yes       |
 |description|IA description of the HTTP Response, which may include HTML tags.| No      |
 
-### Template Parameter (optional)
-This can be used to add the template paramter of each api operation. Template parameter block supports the following:
+### Template Parameters (optional)
+This can be used to add the template paramters of each api operation. Template parameters block supports the following:
 |Variable|Description| Required? |
 |:----------|:-------------|-----------|
 |name|The Name of this Template Parameter.| Yes       |

--- a/main.tf
+++ b/main.tf
@@ -72,12 +72,12 @@ resource "azurerm_api_management_api_operation" "apim_api_operation" {
     }
   }
   dynamic "template_parameter" {
-    for_each = (each.value.template_parameter == null) ? [] : [1]
+    for_each = (each.value.template_parameters == null) ? [] : each.value.template_parameters
     content {
-      name          = each.value.template_parameter.name
-      required      = each.value.template_parameter.required
-      type          = each.value.template_parameter.type
-      default_value = (each.value.template_parameter.default_value == null) ? null : each.value.template_parameter.default_value
+      name          = template_parameter.value["name"]
+      required      = template_parameter.value["required"]
+      type          = template_parameter.value["type"]
+      default_value = (template_parameter.value["default_value"] == null) ? null : template_parameter.value["default_value"]
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -88,12 +88,12 @@ variable "api_operations" {
       type          = string
       default_value = optional(string)
     })))
-    template_parameter = optional(object({
+    template_parameters = optional(list(object({
       name          = string
       required      = string
       type          = string
       default_value = optional(string)
-    }))
+    })))
     response = optional(object({
       status_code = string
       description = optional(string)


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/HMIS-1249

### Change description ###

Existing code for this module only support one template parameter. But in our project, we need more than one template parameter for an endpoint.  I have made the changes and checked on sbox. It looks fine.

![image](https://github.com/hmcts/terraform-module-apim-api/assets/84805836/95a8a6d1-5ed1-4d7d-bf8c-65fe14cd25aa)

**Does this PR introduce a breaking change?** (check one with "x")
[ ] Yes
[x] No